### PR TITLE
Link static lib if PAHO_LINK_STATIC is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,14 @@ if(LIBVDA5050PP_SPTN_DEP_LOCAL)
 endif()
 
 
+# use static lib
+set(_PAHO_MQTT_CPP_LIB_NAME paho-mqttpp3)
+option(PAHO_LINK_STATIC "Use static Paho MQTT CPP library" ON)
+if(PAHO_LINK_STATIC)
+  set(_PAHO_MQTT_CPP_LIB_NAME ${_PAHO_MQTT_CPP_LIB_NAME}-static)
+endif()
+
+
 # Compiler flag function
 include(CheckCXXCompilerFlag)
 function(set_compiler_flag flag)

--- a/extra/mqtt_connector/CMakeLists.txt
+++ b/extra/mqtt_connector/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(mqtt_connector STATIC
   src/mqtt_connector.cpp
 )
 target_link_libraries(mqtt_connector PUBLIC vda5050++)
-target_link_libraries(mqtt_connector PRIVATE json_model PahoMqttCpp::paho-mqttpp3-static)
+target_link_libraries(mqtt_connector PRIVATE json_model PahoMqttCpp::${_PAHO_MQTT_CPP_LIB_NAME})
 target_include_directories(mqtt_connector PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
## Purpose
Avoid `-static` when building as a static library 
with set(PAHO_LINK_STATIC OFF)